### PR TITLE
feat: add KubernetesVersion to Describe Odigos in UI

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -347,6 +347,7 @@ type ComplexityRoot struct {
 		HasErrors            func(childComplexity int) int
 		InstallationMethod   func(childComplexity int) int
 		IsSettled            func(childComplexity int) int
+		KubernetesVersion    func(childComplexity int) int
 		NodeCollector        func(childComplexity int) int
 		NumberOfDestinations func(childComplexity int) int
 		NumberOfSources      func(childComplexity int) int
@@ -1908,6 +1909,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.OdigosAnalyze.IsSettled(childComplexity), true
+
+	case "OdigosAnalyze.kubernetesVersion":
+		if e.complexity.OdigosAnalyze.KubernetesVersion == nil {
+			break
+		}
+
+		return e.complexity.OdigosAnalyze.KubernetesVersion(childComplexity), true
 
 	case "OdigosAnalyze.nodeCollector":
 		if e.complexity.OdigosAnalyze.NodeCollector == nil {
@@ -11677,6 +11685,60 @@ func (ec *executionContext) fieldContext_OdigosAnalyze_odigosVersion(_ context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _OdigosAnalyze_kubernetesVersion(ctx context.Context, field graphql.CollectedField, obj *model.OdigosAnalyze) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OdigosAnalyze_kubernetesVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KubernetesVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.EntityProperty)
+	fc.Result = res
+	return ec.marshalNEntityProperty2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐEntityProperty(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OdigosAnalyze_kubernetesVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OdigosAnalyze",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_EntityProperty_name(ctx, field)
+			case "value":
+				return ec.fieldContext_EntityProperty_value(ctx, field)
+			case "status":
+				return ec.fieldContext_EntityProperty_status(ctx, field)
+			case "explain":
+				return ec.fieldContext_EntityProperty_explain(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EntityProperty", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _OdigosAnalyze_tier(ctx context.Context, field graphql.CollectedField, obj *model.OdigosAnalyze) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_OdigosAnalyze_tier(ctx, field)
 	if err != nil {
@@ -14139,6 +14201,8 @@ func (ec *executionContext) fieldContext_Query_describeOdigos(_ context.Context,
 			switch field.Name {
 			case "odigosVersion":
 				return ec.fieldContext_OdigosAnalyze_odigosVersion(ctx, field)
+			case "kubernetesVersion":
+				return ec.fieldContext_OdigosAnalyze_kubernetesVersion(ctx, field)
 			case "tier":
 				return ec.fieldContext_OdigosAnalyze_tier(ctx, field)
 			case "installationMethod":
@@ -21148,6 +21212,11 @@ func (ec *executionContext) _OdigosAnalyze(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("OdigosAnalyze")
 		case "odigosVersion":
 			out.Values[i] = ec._OdigosAnalyze_odigosVersion(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "kubernetesVersion":
+			out.Values[i] = ec._OdigosAnalyze_kubernetesVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -416,6 +416,7 @@ type NodeCollectorAnalyze struct {
 
 type OdigosAnalyze struct {
 	OdigosVersion        *EntityProperty          `json:"odigosVersion"`
+	KubernetesVersion    *EntityProperty          `json:"kubernetesVersion"`
 	Tier                 *EntityProperty          `json:"tier"`
 	InstallationMethod   *EntityProperty          `json:"installationMethod"`
 	NumberOfDestinations int                      `json:"numberOfDestinations"`

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -574,6 +574,7 @@ type NodeCollectorAnalyze {
 
 type OdigosAnalyze {
   odigosVersion: EntityProperty!
+  kubernetesVersion: EntityProperty!
   tier: EntityProperty!
   installationMethod: EntityProperty!
   numberOfDestinations: Int!

--- a/frontend/services/describe/odigos_describe/odigos_describe.go
+++ b/frontend/services/describe/odigos_describe/odigos_describe.go
@@ -30,6 +30,7 @@ func convertOdigosToGQL(odigos *odigos.OdigosAnalyze) *model.OdigosAnalyze {
 	}
 	return &model.OdigosAnalyze{
 		OdigosVersion:        describe_utils.ConvertEntityPropertyToGQL(&odigos.OdigosVersion),
+		KubernetesVersion:    describe_utils.ConvertEntityPropertyToGQL(&odigos.KubernetesVersion),
 		Tier:                 describe_utils.ConvertEntityPropertyToGQL(&odigos.Tier),
 		InstallationMethod:   describe_utils.ConvertEntityPropertyToGQL(&odigos.InstallationMethod),
 		NumberOfDestinations: odigos.NumberOfDestinations,

--- a/frontend/webapp/graphql/queries/describe.ts
+++ b/frontend/webapp/graphql/queries/describe.ts
@@ -9,6 +9,12 @@ export const DESCRIBE_ODIGOS = gql`
         status
         explain
       }
+      kubernetesVersion {
+        name
+        value
+        status
+        explain
+      }
       tier {
         name
         value

--- a/frontend/webapp/hooks/describe/useDescribeOdigos.ts
+++ b/frontend/webapp/hooks/describe/useDescribeOdigos.ts
@@ -15,6 +15,7 @@ export const useDescribeOdigos = () => {
 
     const payload: Record<string, any> = {
       [`${code.odigosVersion.name}@tooltip=${code.odigosVersion.explain}`]: code.odigosVersion.value,
+      [`${code.kubernetesVersion.name}@tooltip=${code.kubernetesVersion.explain}`]: code.kubernetesVersion.value,
       [`${code.tier.name}@tooltip=${code.tier.explain}`]: code.tier.value,
       [`${code.installationMethod.name}@tooltip=${code.installationMethod.explain}`]: code.installationMethod.value,
       'Number Of Sources': code.numberOfSources,

--- a/frontend/webapp/types/describe.ts
+++ b/frontend/webapp/types/describe.ts
@@ -103,6 +103,7 @@ interface NodeCollectorAnalyze {
 
 interface OdigosAnalyze {
   odigosVersion: EntityProperty;
+  kubernetesVersion: EntityProperty;
   tier: EntityProperty;
   installationMethod: EntityProperty;
   numberOfDestinations: number;


### PR DESCRIPTION
This pull request introduces support for the `kubernetesVersion` field in the `OdigosAnalyze` type across the codebase. The changes span multiple files, including GraphQL schema definitions, generated code, and TypeScript types.

Key changes include:

### GraphQL Schema and Resolvers:

* Added `kubernetesVersion` field to the `OdigosAnalyze` type in the GraphQL schema (`frontend/graph/schema.graphqls`).
* Updated various resolver functions to handle the new `kubernetesVersion` field, including `fieldContext_OdigosAnalyze_kubernetesVersion` and `_OdigosAnalyze_kubernetesVersion` (`frontend/graph/generated.go`). [[1]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R11688-R11741) [[2]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R14204-R14205) [[3]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R21218-R21222)

### TypeScript and Data Handling:

* Modified the `OdigosAnalyze` interface to include the `kubernetesVersion` field in TypeScript types (`frontend/webapp/types/describe.ts`).
* Updated the `useDescribeOdigos` hook to handle the `kubernetesVersion` field (`frontend/webapp/hooks/describe/useDescribeOdigos.ts`).
* Enhanced the GraphQL query `DESCRIBE_ODIGOS` to request the `kubernetesVersion` field (`frontend/webapp/graphql/queries/describe.ts`).

### Backend Logic:

* Updated the `convertOdigosToGQL` function to map the `kubernetesVersion` field from the backend model to the GraphQL type (`frontend/services/describe/odigos_describe/odigos_describe.go`).

These changes ensure that the `kubernetesVersion` field is properly integrated and accessible throughout the application, from the backend to the frontend.


<img width="663" alt="Screenshot 2025-01-21 at 9 37 21" src="https://github.com/user-attachments/assets/61a8c7ff-0cc8-4a5b-84b4-db0b7d9d2cc8" />
