### PR TITLE
refactor: restructure sampling SourcesScope into multi-list SourcesScopes

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1300,11 +1300,10 @@ type ComplexityRoot struct {
 		ProfileJSON func(childComplexity int) int
 	}
 
-	SourcesScope struct {
-		WorkloadKind      func(childComplexity int) int
-		WorkloadLanguage  func(childComplexity int) int
-		WorkloadName      func(childComplexity int) int
-		WorkloadNamespace func(childComplexity int) int
+	SourcesScopes struct {
+		Languages  func(childComplexity int) int
+		Namespaces func(childComplexity int) int
+		Sources    func(childComplexity int) int
 	}
 
 	SpanAttributeFilter struct {
@@ -7199,33 +7198,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SourceProfilingResult.ProfileJSON(childComplexity), true
 
-	case "SourcesScope.workloadKind":
-		if e.complexity.SourcesScope.WorkloadKind == nil {
+	case "SourcesScopes.languages":
+		if e.complexity.SourcesScopes.Languages == nil {
 			break
 		}
 
-		return e.complexity.SourcesScope.WorkloadKind(childComplexity), true
+		return e.complexity.SourcesScopes.Languages(childComplexity), true
 
-	case "SourcesScope.workloadLanguage":
-		if e.complexity.SourcesScope.WorkloadLanguage == nil {
+	case "SourcesScopes.namespaces":
+		if e.complexity.SourcesScopes.Namespaces == nil {
 			break
 		}
 
-		return e.complexity.SourcesScope.WorkloadLanguage(childComplexity), true
+		return e.complexity.SourcesScopes.Namespaces(childComplexity), true
 
-	case "SourcesScope.workloadName":
-		if e.complexity.SourcesScope.WorkloadName == nil {
+	case "SourcesScopes.sources":
+		if e.complexity.SourcesScopes.Sources == nil {
 			break
 		}
 
-		return e.complexity.SourcesScope.WorkloadName(childComplexity), true
-
-	case "SourcesScope.workloadNamespace":
-		if e.complexity.SourcesScope.WorkloadNamespace == nil {
-			break
-		}
-
-		return e.complexity.SourcesScope.WorkloadNamespace(childComplexity), true
+		return e.complexity.SourcesScopes.Sources(childComplexity), true
 
 	case "SpanAttributeFilter.attributeKey":
 		if e.complexity.SpanAttributeFilter.AttributeKey == nil {
@@ -7592,7 +7584,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRemoteConfigRolloutInput,
 		ec.unmarshalInputSamplingConfigInput,
 		ec.unmarshalInputServiceNameFilterInput,
-		ec.unmarshalInputSourcesScopeInput,
+		ec.unmarshalInputSourcesScopesInput,
 		ec.unmarshalInputSpanAttributeFilterInput,
 		ec.unmarshalInputStringConditionInput,
 		ec.unmarshalInputTailSamplingConfigInput,
@@ -17767,9 +17759,9 @@ func (ec *executionContext) _CostReductionRule_sourceScopes(ctx context.Context,
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.SourcesScope)
+	res := resTmp.(*model.SourcesScopes)
 	fc.Result = res
-	return ec.marshalOSourcesScope2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeᚄ(ctx, field.Selections, res)
+	return ec.marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CostReductionRule_sourceScopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -17780,16 +17772,14 @@ func (ec *executionContext) fieldContext_CostReductionRule_sourceScopes(_ contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "workloadName":
-				return ec.fieldContext_SourcesScope_workloadName(ctx, field)
-			case "workloadKind":
-				return ec.fieldContext_SourcesScope_workloadKind(ctx, field)
-			case "workloadNamespace":
-				return ec.fieldContext_SourcesScope_workloadNamespace(ctx, field)
-			case "workloadLanguage":
-				return ec.fieldContext_SourcesScope_workloadLanguage(ctx, field)
+			case "sources":
+				return ec.fieldContext_SourcesScopes_sources(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+			case "languages":
+				return ec.fieldContext_SourcesScopes_languages(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type SourcesScope", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type SourcesScopes", field.Name)
 		},
 	}
 	return fc, nil
@@ -24133,9 +24123,9 @@ func (ec *executionContext) _HighlyRelevantOperationRule_sourceScopes(ctx contex
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.SourcesScope)
+	res := resTmp.(*model.SourcesScopes)
 	fc.Result = res
-	return ec.marshalOSourcesScope2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeᚄ(ctx, field.Selections, res)
+	return ec.marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HighlyRelevantOperationRule_sourceScopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24146,16 +24136,14 @@ func (ec *executionContext) fieldContext_HighlyRelevantOperationRule_sourceScope
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "workloadName":
-				return ec.fieldContext_SourcesScope_workloadName(ctx, field)
-			case "workloadKind":
-				return ec.fieldContext_SourcesScope_workloadKind(ctx, field)
-			case "workloadNamespace":
-				return ec.fieldContext_SourcesScope_workloadNamespace(ctx, field)
-			case "workloadLanguage":
-				return ec.fieldContext_SourcesScope_workloadLanguage(ctx, field)
+			case "sources":
+				return ec.fieldContext_SourcesScopes_sources(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+			case "languages":
+				return ec.fieldContext_SourcesScopes_languages(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type SourcesScope", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type SourcesScopes", field.Name)
 		},
 	}
 	return fc, nil
@@ -37905,9 +37893,9 @@ func (ec *executionContext) _NoisyOperationRule_sourceScopes(ctx context.Context
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.SourcesScope)
+	res := resTmp.(*model.SourcesScopes)
 	fc.Result = res
-	return ec.marshalOSourcesScope2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeᚄ(ctx, field.Selections, res)
+	return ec.marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_NoisyOperationRule_sourceScopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -37918,16 +37906,14 @@ func (ec *executionContext) fieldContext_NoisyOperationRule_sourceScopes(_ conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "workloadName":
-				return ec.fieldContext_SourcesScope_workloadName(ctx, field)
-			case "workloadKind":
-				return ec.fieldContext_SourcesScope_workloadKind(ctx, field)
-			case "workloadNamespace":
-				return ec.fieldContext_SourcesScope_workloadNamespace(ctx, field)
-			case "workloadLanguage":
-				return ec.fieldContext_SourcesScope_workloadLanguage(ctx, field)
+			case "sources":
+				return ec.fieldContext_SourcesScopes_sources(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+			case "languages":
+				return ec.fieldContext_SourcesScopes_languages(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type SourcesScope", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type SourcesScopes", field.Name)
 		},
 	}
 	return fc, nil
@@ -46781,8 +46767,8 @@ func (ec *executionContext) fieldContext_SourceProfilingResult_profileJson(_ con
 	return fc, nil
 }
 
-func (ec *executionContext) _SourcesScope_workloadName(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScope) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_SourcesScope_workloadName(ctx, field)
+func (ec *executionContext) _SourcesScopes_sources(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScopes) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourcesScopes_sources(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -46795,7 +46781,7 @@ func (ec *executionContext) _SourcesScope_workloadName(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.WorkloadName, nil
+		return obj.Sources, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -46804,14 +46790,63 @@ func (ec *executionContext) _SourcesScope_workloadName(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.([]*model.K8sWorkloadID)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOK8sWorkloadId2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadIDᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_SourcesScope_workloadName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SourcesScopes_sources(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "SourcesScope",
+		Object:     "SourcesScopes",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "namespace":
+				return ec.fieldContext_K8sWorkloadId_namespace(ctx, field)
+			case "kind":
+				return ec.fieldContext_K8sWorkloadId_kind(ctx, field)
+			case "name":
+				return ec.fieldContext_K8sWorkloadId_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadId", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourcesScopes_namespaces(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScopes) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Namespaces, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourcesScopes_namespaces(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourcesScopes",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -46822,8 +46857,8 @@ func (ec *executionContext) fieldContext_SourcesScope_workloadName(_ context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _SourcesScope_workloadKind(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScope) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_SourcesScope_workloadKind(ctx, field)
+func (ec *executionContext) _SourcesScopes_languages(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScopes) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourcesScopes_languages(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -46836,7 +46871,7 @@ func (ec *executionContext) _SourcesScope_workloadKind(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.WorkloadKind, nil
+		return obj.Languages, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -46845,96 +46880,14 @@ func (ec *executionContext) _SourcesScope_workloadKind(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.K8sResourceKind)
+	res := resTmp.([]model.SamplingWorkloadLanguage)
 	fc.Result = res
-	return ec.marshalOK8sResourceKind2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sResourceKind(ctx, field.Selections, res)
+	return ec.marshalOSamplingWorkloadLanguage2ᚕgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguageᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_SourcesScope_workloadKind(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SourcesScopes_languages(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "SourcesScope",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type K8sResourceKind does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _SourcesScope_workloadNamespace(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScope) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_SourcesScope_workloadNamespace(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.WorkloadNamespace, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_SourcesScope_workloadNamespace(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "SourcesScope",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _SourcesScope_workloadLanguage(ctx context.Context, field graphql.CollectedField, obj *model.SourcesScope) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_SourcesScope_workloadLanguage(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.WorkloadLanguage, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.SamplingWorkloadLanguage)
-	fc.Result = res
-	return ec.marshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_SourcesScope_workloadLanguage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "SourcesScope",
+		Object:     "SourcesScopes",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -51166,7 +51119,7 @@ func (ec *executionContext) unmarshalInputCostReductionRuleInput(ctx context.Con
 			it.Disabled = data
 		case "sourceScopes":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceScopes"))
-			data, err := ec.unmarshalOSourcesScopeInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeInputᚄ(ctx, v)
+			data, err := ec.unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -51717,7 +51670,7 @@ func (ec *executionContext) unmarshalInputHighlyRelevantOperationRuleInput(ctx c
 			it.Disabled = data
 		case "sourceScopes":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceScopes"))
-			data, err := ec.unmarshalOSourcesScopeInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeInputᚄ(ctx, v)
+			data, err := ec.unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -52930,7 +52883,7 @@ func (ec *executionContext) unmarshalInputNoisyOperationRuleInput(ctx context.Co
 			it.Disabled = data
 		case "sourceScopes":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceScopes"))
-			data, err := ec.unmarshalOSourcesScopeInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeInputᚄ(ctx, v)
+			data, err := ec.unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -53372,48 +53325,41 @@ func (ec *executionContext) unmarshalInputServiceNameFilterInput(ctx context.Con
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputSourcesScopeInput(ctx context.Context, obj any) (model.SourcesScopeInput, error) {
-	var it model.SourcesScopeInput
+func (ec *executionContext) unmarshalInputSourcesScopesInput(ctx context.Context, obj any) (model.SourcesScopesInput, error) {
+	var it model.SourcesScopesInput
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"workloadName", "workloadKind", "workloadNamespace", "workloadLanguage"}
+	fieldsInOrder := [...]string{"sources", "namespaces", "languages"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "workloadName":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workloadName"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+		case "sources":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sources"))
+			data, err := ec.unmarshalOK8sSourceId2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sSourceIDᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.WorkloadName = data
-		case "workloadKind":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workloadKind"))
-			data, err := ec.unmarshalOK8sResourceKind2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sResourceKind(ctx, v)
+			it.Sources = data
+		case "namespaces":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespaces"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.WorkloadKind = data
-		case "workloadNamespace":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workloadNamespace"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Namespaces = data
+		case "languages":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("languages"))
+			data, err := ec.unmarshalOSamplingWorkloadLanguage2ᚕgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguageᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.WorkloadNamespace = data
-		case "workloadLanguage":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workloadLanguage"))
-			data, err := ec.unmarshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.WorkloadLanguage = data
+			it.Languages = data
 		}
 	}
 
@@ -63710,25 +63656,23 @@ func (ec *executionContext) _SourceProfilingResult(ctx context.Context, sel ast.
 	return out
 }
 
-var sourcesScopeImplementors = []string{"SourcesScope"}
+var sourcesScopesImplementors = []string{"SourcesScopes"}
 
-func (ec *executionContext) _SourcesScope(ctx context.Context, sel ast.SelectionSet, obj *model.SourcesScope) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, sourcesScopeImplementors)
+func (ec *executionContext) _SourcesScopes(ctx context.Context, sel ast.SelectionSet, obj *model.SourcesScopes) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sourcesScopesImplementors)
 
 	out := graphql.NewFieldSet(fields)
 	deferred := make(map[string]*graphql.FieldSet)
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("SourcesScope")
-		case "workloadName":
-			out.Values[i] = ec._SourcesScope_workloadName(ctx, field, obj)
-		case "workloadKind":
-			out.Values[i] = ec._SourcesScope_workloadKind(ctx, field, obj)
-		case "workloadNamespace":
-			out.Values[i] = ec._SourcesScope_workloadNamespace(ctx, field, obj)
-		case "workloadLanguage":
-			out.Values[i] = ec._SourcesScope_workloadLanguage(ctx, field, obj)
+			out.Values[i] = graphql.MarshalString("SourcesScopes")
+		case "sources":
+			out.Values[i] = ec._SourcesScopes_sources(ctx, field, obj)
+		case "namespaces":
+			out.Values[i] = ec._SourcesScopes_namespaces(ctx, field, obj)
+		case "languages":
+			out.Values[i] = ec._SourcesScopes_languages(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -67598,6 +67542,16 @@ func (ec *executionContext) marshalNSamplingRules2ᚖgithubᚗcomᚋodigosᚑio�
 	return ec._SamplingRules(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNSamplingWorkloadLanguage2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx context.Context, v any) (model.SamplingWorkloadLanguage, error) {
+	var res model.SamplingWorkloadLanguage
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSamplingWorkloadLanguage2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx context.Context, sel ast.SelectionSet, v model.SamplingWorkloadLanguage) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) marshalNServiceMap2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐServiceMap(ctx context.Context, sel ast.SelectionSet, v model.ServiceMap) graphql.Marshaler {
 	return ec._ServiceMap(ctx, sel, &v)
 }
@@ -67988,21 +67942,6 @@ func (ec *executionContext) marshalNSourceContainer2ᚖgithubᚗcomᚋodigosᚑi
 		return graphql.Null
 	}
 	return ec._SourceContainer(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNSourcesScope2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScope(ctx context.Context, sel ast.SelectionSet, v *model.SourcesScope) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._SourcesScope(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNSourcesScopeInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeInput(ctx context.Context, v any) (*model.SourcesScopeInput, error) {
-	res, err := ec.unmarshalInputSourcesScopeInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNSpanAttributeFilter2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSpanAttributeFilter(ctx context.Context, sel ast.SelectionSet, v *model.SpanAttributeFilter) graphql.Marshaler {
@@ -69711,6 +69650,24 @@ func (ec *executionContext) marshalOK8sResourceKind2ᚖgithubᚗcomᚋodigosᚑi
 	return v
 }
 
+func (ec *executionContext) unmarshalOK8sSourceId2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sSourceIDᚄ(ctx context.Context, v any) ([]*model.K8sSourceID, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.K8sSourceID, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNK8sSourceId2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sSourceID(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) marshalOK8sWorkloadAgentEnabled2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadAgentEnabled(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadAgentEnabled) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -69960,6 +69917,53 @@ func (ec *executionContext) marshalOK8sWorkloadContainerOverrides2ᚖgithubᚗco
 		return graphql.Null
 	}
 	return ec._K8sWorkloadContainerOverrides(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOK8sWorkloadId2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadIDᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadID) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNK8sWorkloadId2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadID(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOK8sWorkloadPod2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadPodᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadPod) graphql.Marshaler {
@@ -70660,6 +70664,71 @@ func (ec *executionContext) unmarshalOSamplingConfigInput2ᚖgithubᚗcomᚋodig
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalOSamplingWorkloadLanguage2ᚕgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguageᚄ(ctx context.Context, v any) ([]model.SamplingWorkloadLanguage, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]model.SamplingWorkloadLanguage, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNSamplingWorkloadLanguage2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOSamplingWorkloadLanguage2ᚕgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguageᚄ(ctx context.Context, sel ast.SelectionSet, v []model.SamplingWorkloadLanguage) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSamplingWorkloadLanguage2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx context.Context, v any) (*model.SamplingWorkloadLanguage, error) {
 	if v == nil {
 		return nil, nil
@@ -70795,69 +70864,19 @@ func (ec *executionContext) marshalOSourceProfilingResult2ᚖgithubᚗcomᚋodig
 	return ec._SourceProfilingResult(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOSourcesScope2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SourcesScope) graphql.Marshaler {
+func (ec *executionContext) marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx context.Context, sel ast.SelectionSet, v *model.SourcesScopes) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNSourcesScope2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScope(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
+	return ec._SourcesScopes(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalOSourcesScopeInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeInputᚄ(ctx context.Context, v any) ([]*model.SourcesScopeInput, error) {
+func (ec *executionContext) unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx context.Context, v any) (*model.SourcesScopesInput, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var vSlice []any
-	vSlice = graphql.CoerceList(v)
-	var err error
-	res := make([]*model.SourcesScopeInput, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNSourcesScopeInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopeInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
+	res, err := ec.unmarshalInputSourcesScopesInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOSpanAttributeFilter2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSpanAttributeFilterᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SpanAttributeFilter) graphql.Marshaler {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -313,7 +313,7 @@ type CostReductionRule struct {
 	RuleID           string                        `json:"ruleId"`
 	Name             *string                       `json:"name,omitempty"`
 	Disabled         bool                          `json:"disabled"`
-	SourceScopes     []*SourcesScope               `json:"sourceScopes,omitempty"`
+	SourceScopes     *SourcesScopes                `json:"sourceScopes,omitempty"`
 	Operation        *TailSamplingOperationMatcher `json:"operation,omitempty"`
 	PercentageAtMost float64                       `json:"percentageAtMost"`
 	Notes            *string                       `json:"notes,omitempty"`
@@ -322,7 +322,7 @@ type CostReductionRule struct {
 type CostReductionRuleInput struct {
 	Name             *string                            `json:"name,omitempty"`
 	Disabled         *bool                              `json:"disabled,omitempty"`
-	SourceScopes     []*SourcesScopeInput               `json:"sourceScopes,omitempty"`
+	SourceScopes     *SourcesScopesInput                `json:"sourceScopes,omitempty"`
 	Operation        *TailSamplingOperationMatcherInput `json:"operation,omitempty"`
 	PercentageAtMost float64                            `json:"percentageAtMost"`
 	Notes            *string                            `json:"notes,omitempty"`
@@ -618,7 +618,7 @@ type HighlyRelevantOperationRule struct {
 	RuleID            string                        `json:"ruleId"`
 	Name              *string                       `json:"name,omitempty"`
 	Disabled          bool                          `json:"disabled"`
-	SourceScopes      []*SourcesScope               `json:"sourceScopes,omitempty"`
+	SourceScopes      *SourcesScopes                `json:"sourceScopes,omitempty"`
 	Error             bool                          `json:"error"`
 	DurationAtLeastMs *int                          `json:"durationAtLeastMs,omitempty"`
 	Operation         *TailSamplingOperationMatcher `json:"operation,omitempty"`
@@ -629,7 +629,7 @@ type HighlyRelevantOperationRule struct {
 type HighlyRelevantOperationRuleInput struct {
 	Name              *string                            `json:"name,omitempty"`
 	Disabled          *bool                              `json:"disabled,omitempty"`
-	SourceScopes      []*SourcesScopeInput               `json:"sourceScopes,omitempty"`
+	SourceScopes      *SourcesScopesInput                `json:"sourceScopes,omitempty"`
 	Error             *bool                              `json:"error,omitempty"`
 	DurationAtLeastMs *int                               `json:"durationAtLeastMs,omitempty"`
 	Operation         *TailSamplingOperationMatcherInput `json:"operation,omitempty"`
@@ -1227,7 +1227,7 @@ type NoisyOperationRule struct {
 	RuleID           string                        `json:"ruleId"`
 	Name             *string                       `json:"name,omitempty"`
 	Disabled         bool                          `json:"disabled"`
-	SourceScopes     []*SourcesScope               `json:"sourceScopes,omitempty"`
+	SourceScopes     *SourcesScopes                `json:"sourceScopes,omitempty"`
 	Operation        *HeadSamplingOperationMatcher `json:"operation,omitempty"`
 	PercentageAtMost *float64                      `json:"percentageAtMost,omitempty"`
 	Notes            *string                       `json:"notes,omitempty"`
@@ -1236,7 +1236,7 @@ type NoisyOperationRule struct {
 type NoisyOperationRuleInput struct {
 	Name             *string                            `json:"name,omitempty"`
 	Disabled         *bool                              `json:"disabled,omitempty"`
-	SourceScopes     []*SourcesScopeInput               `json:"sourceScopes,omitempty"`
+	SourceScopes     *SourcesScopesInput                `json:"sourceScopes,omitempty"`
 	Operation        *HeadSamplingOperationMatcherInput `json:"operation,omitempty"`
 	PercentageAtMost *float64                           `json:"percentageAtMost,omitempty"`
 	Notes            *string                            `json:"notes,omitempty"`
@@ -1572,18 +1572,16 @@ type SourceProfilingResult struct {
 	ProfileJSON string `json:"profileJson"`
 }
 
-type SourcesScope struct {
-	WorkloadName      *string                   `json:"workloadName,omitempty"`
-	WorkloadKind      *K8sResourceKind          `json:"workloadKind,omitempty"`
-	WorkloadNamespace *string                   `json:"workloadNamespace,omitempty"`
-	WorkloadLanguage  *SamplingWorkloadLanguage `json:"workloadLanguage,omitempty"`
+type SourcesScopes struct {
+	Sources    []*K8sWorkloadID           `json:"sources,omitempty"`
+	Namespaces []string                   `json:"namespaces,omitempty"`
+	Languages  []SamplingWorkloadLanguage `json:"languages,omitempty"`
 }
 
-type SourcesScopeInput struct {
-	WorkloadName      *string                   `json:"workloadName,omitempty"`
-	WorkloadKind      *K8sResourceKind          `json:"workloadKind,omitempty"`
-	WorkloadNamespace *string                   `json:"workloadNamespace,omitempty"`
-	WorkloadLanguage  *SamplingWorkloadLanguage `json:"workloadLanguage,omitempty"`
+type SourcesScopesInput struct {
+	Sources    []*K8sSourceID             `json:"sources,omitempty"`
+	Namespaces []string                   `json:"namespaces,omitempty"`
+	Languages  []SamplingWorkloadLanguage `json:"languages,omitempty"`
 }
 
 type SpanAttributeFilter struct {

--- a/frontend/graph/sampling.graphqls
+++ b/frontend/graph/sampling.graphqls
@@ -90,19 +90,19 @@ enum SamplingWorkloadLanguage {
   ruby
 }
 
-# scope to limit a sampling rule to specific sources
-type SourcesScope {
-  workloadName: String
-  workloadKind: K8sResourceKind
-  workloadNamespace: String
-  workloadLanguage: SamplingWorkloadLanguage
+# scope to limit a sampling rule to specific sources.
+# each list is OR'd internally; the three lists are AND'd together.
+# empty list (or missing field) means "match all" in that dimension.
+type SourcesScopes {
+  sources: [K8sWorkloadId!]
+  namespaces: [String!]
+  languages: [SamplingWorkloadLanguage!]
 }
 
-input SourcesScopeInput {
-  workloadName: String
-  workloadKind: K8sResourceKind
-  workloadNamespace: String
-  workloadLanguage: SamplingWorkloadLanguage
+input SourcesScopesInput {
+  sources: [K8sSourceId!]
+  namespaces: [String!]
+  languages: [SamplingWorkloadLanguage!]
 }
 
 # ---- Head sampling operation matchers (used by noisy operations) ----
@@ -183,7 +183,7 @@ type NoisyOperationRule {
   ruleId: ID!
   name: String
   disabled: Boolean!
-  sourceScopes: [SourcesScope!]
+  sourceScopes: SourcesScopes
   operation: HeadSamplingOperationMatcher
   # percentage (0-100) of matching traces to keep. unset defaults to 0% (drop all).
   percentageAtMost: Float
@@ -194,7 +194,7 @@ type HighlyRelevantOperationRule {
   ruleId: ID!
   name: String
   disabled: Boolean!
-  sourceScopes: [SourcesScope!]
+  sourceScopes: SourcesScopes
   # if true, only spans with SpanStatus set to Error are considered
   error: Boolean!
   # if set, only operations with duration in ms larger than this value are considered
@@ -209,7 +209,7 @@ type CostReductionRule {
   ruleId: ID!
   name: String
   disabled: Boolean!
-  sourceScopes: [SourcesScope!]
+  sourceScopes: SourcesScopes
   operation: TailSamplingOperationMatcher
   # percentage (0-100) of matching traces to keep. required field.
   percentageAtMost: Float!
@@ -221,7 +221,7 @@ type CostReductionRule {
 input NoisyOperationRuleInput {
   name: String
   disabled: Boolean
-  sourceScopes: [SourcesScopeInput!]
+  sourceScopes: SourcesScopesInput
   operation: HeadSamplingOperationMatcherInput
   percentageAtMost: Float
   notes: String
@@ -230,7 +230,7 @@ input NoisyOperationRuleInput {
 input HighlyRelevantOperationRuleInput {
   name: String
   disabled: Boolean
-  sourceScopes: [SourcesScopeInput!]
+  sourceScopes: SourcesScopesInput
   error: Boolean
   durationAtLeastMs: Int
   operation: TailSamplingOperationMatcherInput
@@ -241,7 +241,7 @@ input HighlyRelevantOperationRuleInput {
 input CostReductionRuleInput {
   name: String
   disabled: Boolean
-  sourceScopes: [SourcesScopeInput!]
+  sourceScopes: SourcesScopesInput
   operation: TailSamplingOperationMatcherInput
   percentageAtMost: Float!
   notes: String

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -846,41 +846,49 @@ func convertUrlTemplatizationFromInput(details *model.ActionFieldsInput, existin
 	for _, g := range details.URLTemplatizationRulesGroups {
 		group := urlactions.UrlTemplatizationRulesGroup{}
 
-		var sourcesScope []k8sconsts.SourcesScope
+		// Fold the URL-templatization filter form into the tri-list SourcesScopes shape:
+		//   * Each WorkloadFilter row → one PodWorkload appended to Sources (with namespace baked in).
+		//   * Singleton fallback path: build one PodWorkload if a workload identity is given,
+		//     otherwise fall back to a namespace-only entry.
+		//   * FilterProgrammingLanguage → Languages.
+		scopes := &k8sconsts.SourcesScopes{}
 		if len(g.WorkloadFilters) > 0 {
 			for _, wf := range g.WorkloadFilters {
-				scope := k8sconsts.SourcesScope{}
+				pw := k8sconsts.PodWorkload{}
 				if g.FilterK8sNamespace != nil {
-					scope.WorkloadNamespace = *g.FilterK8sNamespace
+					pw.Namespace = *g.FilterK8sNamespace
 				}
 				if wf.Kind != nil {
-					scope.WorkloadKind = string(*wf.Kind)
+					pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
 				}
 				if wf.Name != nil {
-					scope.WorkloadName = *wf.Name
+					pw.Name = *wf.Name
 				}
-				if g.FilterProgrammingLanguage != nil {
-					scope.WorkloadLanguage = common.ProgrammingLanguage(*g.FilterProgrammingLanguage)
+				scopes.Sources = append(scopes.Sources, pw)
+			}
+		} else if g.FilterK8sNamespace != nil || g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
+			if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
+				pw := k8sconsts.PodWorkload{}
+				if g.FilterK8sNamespace != nil {
+					pw.Namespace = *g.FilterK8sNamespace
 				}
-				sourcesScope = append(sourcesScope, scope)
+				if g.FilterK8sWorkloadKind != nil {
+					pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
+				}
+				if g.FilterK8sWorkloadName != nil {
+					pw.Name = *g.FilterK8sWorkloadName
+				}
+				scopes.Sources = append(scopes.Sources, pw)
+			} else if g.FilterK8sNamespace != nil {
+				scopes.Namespaces = append(scopes.Namespaces, *g.FilterK8sNamespace)
 			}
-		} else if g.FilterK8sNamespace != nil || g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil || g.FilterProgrammingLanguage != nil {
-			scope := k8sconsts.SourcesScope{}
-			if g.FilterK8sNamespace != nil {
-				scope.WorkloadNamespace = *g.FilterK8sNamespace
-			}
-			if g.FilterK8sWorkloadKind != nil {
-				scope.WorkloadKind = string(*g.FilterK8sWorkloadKind)
-			}
-			if g.FilterK8sWorkloadName != nil {
-				scope.WorkloadName = *g.FilterK8sWorkloadName
-			}
-			if g.FilterProgrammingLanguage != nil {
-				scope.WorkloadLanguage = common.ProgrammingLanguage(*g.FilterProgrammingLanguage)
-			}
-			sourcesScope = append(sourcesScope, scope)
 		}
-		group.SourcesScope = sourcesScope
+		if g.FilterProgrammingLanguage != nil {
+			scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(*g.FilterProgrammingLanguage))
+		}
+		if len(scopes.Sources) > 0 || len(scopes.Namespaces) > 0 || len(scopes.Languages) > 0 {
+			group.SourcesScopes = scopes
+		}
 
 		for _, rule := range g.TemplatizationRules {
 			r := urlactions.URLTemplatizationRule{
@@ -907,24 +915,35 @@ func convertUrlTemplatizationToModel(cfg *urlactions.URLTemplatizationConfig) []
 	for _, g := range cfg.TemplatizationRulesGroups {
 		group := &model.URLTemplatizationRulesGroup{}
 
-		for _, scope := range g.SourcesScope {
-			if scope.WorkloadKind != "" || scope.WorkloadName != "" {
-				filter := &model.TemplatizationWorkloadFilter{}
-				if scope.WorkloadKind != "" {
-					kind := model.K8sResourceKind(scope.WorkloadKind)
-					filter.Kind = &kind
+		// Unfold tri-list SourcesScopes back into the URL-templatization filter form.
+		// The GraphQL shape exposes only single-value FilterK8sNamespace and
+		// FilterProgrammingLanguage, so multi-namespace/multi-language scopes are
+		// projected to the first entry (best-effort; the wire format predates the list).
+		if g.SourcesScopes != nil {
+			for _, src := range g.SourcesScopes.Sources {
+				if src.Kind != "" || src.Name != "" {
+					filter := &model.TemplatizationWorkloadFilter{}
+					if src.Kind != "" {
+						kind := model.K8sResourceKind(src.Kind)
+						filter.Kind = &kind
+					}
+					if src.Name != "" {
+						name := src.Name
+						filter.Name = &name
+					}
+					group.WorkloadFilters = append(group.WorkloadFilters, filter)
 				}
-				if scope.WorkloadName != "" {
-					filter.Name = &scope.WorkloadName
+				if src.Namespace != "" && group.FilterK8sNamespace == nil {
+					ns := src.Namespace
+					group.FilterK8sNamespace = &ns
 				}
-				group.WorkloadFilters = append(group.WorkloadFilters, filter)
 			}
-
-			if scope.WorkloadNamespace != "" && group.FilterK8sNamespace == nil {
-				group.FilterK8sNamespace = &scope.WorkloadNamespace
+			if group.FilterK8sNamespace == nil && len(g.SourcesScopes.Namespaces) > 0 {
+				ns := g.SourcesScopes.Namespaces[0]
+				group.FilterK8sNamespace = &ns
 			}
-			if scope.WorkloadLanguage != "" && group.FilterProgrammingLanguage == nil {
-				lang := string(scope.WorkloadLanguage)
+			if len(g.SourcesScopes.Languages) > 0 {
+				lang := string(g.SourcesScopes.Languages[0])
 				group.FilterProgrammingLanguage = &lang
 			}
 		}

--- a/frontend/services/instrumentationrule.go
+++ b/frontend/services/instrumentationrule.go
@@ -355,7 +355,7 @@ func CreateInstrumentationRule(ctx context.Context, input model.InstrumentationR
 	notes := *input.Notes
 	disabled := *input.Disabled
 
-	var sourcesScopes []k8sconsts.SourcesScope
+	var sourcesScopes *k8sconsts.SourcesScopes
 	if input.SourcesScopes != nil {
 		sourcesScopes = convertSourcesScopeInput(input.SourcesScopes)
 	}
@@ -425,37 +425,72 @@ func handleNotFoundError(err error, id string, entity string) error {
 	return fmt.Errorf("error getting %s: %w", entity, err)
 }
 
-// Converts GraphQL InstrumentationRuleSourcesScopeInput list to the CRD []k8sconsts.SourcesScope for spec.sourcesScopes
-func convertSourcesScopeInput(scopes []*model.InstrumentationRuleSourcesScopeInput) []k8sconsts.SourcesScope {
-	var result []k8sconsts.SourcesScope
+// convertSourcesScopeInput folds the row-per-criterion GraphQL shape into the
+// single-object tri-list CRD shape. Each input row contributes to at most one
+// of Sources/Namespaces (workload identity vs. namespace-only) plus optionally
+// Languages. The CRD model has no equivalent for the legacy `containerName`
+// field, so it is dropped on conversion.
+func convertSourcesScopeInput(scopes []*model.InstrumentationRuleSourcesScopeInput) *k8sconsts.SourcesScopes {
+	if len(scopes) == 0 {
+		return nil
+	}
+	out := &k8sconsts.SourcesScopes{}
 	for _, scope := range scopes {
 		if scope == nil {
 			continue
 		}
-		result = append(result, k8sconsts.SourcesScope{
-			WorkloadName:      DerefString(scope.WorkloadName),
-			WorkloadKind:      DerefK8sResourceKind(scope.WorkloadKind),
-			WorkloadNamespace: DerefString(scope.WorkloadNamespace),
-			ContainerName:     DerefString(scope.ContainerName),
-			WorkloadLanguage:  DerefSamplingWorkloadLanguage(scope.WorkloadLanguage),
-		})
+		name := DerefString(scope.WorkloadName)
+		kind := DerefK8sResourceKind(scope.WorkloadKind)
+		namespace := DerefString(scope.WorkloadNamespace)
+		language := DerefSamplingWorkloadLanguage(scope.WorkloadLanguage)
+
+		switch {
+		case name != "" || kind != "":
+			out.Sources = append(out.Sources, k8sconsts.PodWorkload{
+				Name:      name,
+				Namespace: namespace,
+				Kind:      k8sconsts.WorkloadKind(kind),
+			})
+		case namespace != "":
+			out.Namespaces = append(out.Namespaces, namespace)
+		}
+		if language != "" {
+			out.Languages = append(out.Languages, language)
+		}
 	}
-	return result
+	if len(out.Sources) == 0 && len(out.Namespaces) == 0 && len(out.Languages) == 0 {
+		return nil
+	}
+	return out
 }
 
-// Converts spec.sourcesScopes ([]k8sconsts.SourcesScope) to GraphQL InstrumentationRuleSourcesScope list
-func convertSourcesScope(sourcesScope []k8sconsts.SourcesScope) []*model.InstrumentationRuleSourcesScope {
+// convertSourcesScope unfolds the single-object tri-list CRD shape back into the
+// row-per-criterion GraphQL shape: one row per Source, one per Namespace, one
+// per Language. This is the inverse of convertSourcesScopeInput for the common
+// case of single-dimension rows.
+func convertSourcesScope(scopes *k8sconsts.SourcesScopes) []*model.InstrumentationRuleSourcesScope {
+	if scopes == nil {
+		return nil
+	}
 	var gqlSourcesScope []*model.InstrumentationRuleSourcesScope
-	for _, s := range sourcesScope {
-		scope := s
-		kind := model.K8sResourceKind(scope.WorkloadKind)
-		lang := model.SamplingWorkloadLanguage(scope.WorkloadLanguage)
+	for _, src := range scopes.Sources {
+		row := &model.InstrumentationRuleSourcesScope{
+			WorkloadName:      StringPtrIfNotEmpty(src.Name),
+			WorkloadKind:      K8sResourceKindPtrIfNotEmpty(string(src.Kind)),
+			WorkloadNamespace: StringPtrIfNotEmpty(src.Namespace),
+		}
+		gqlSourcesScope = append(gqlSourcesScope, row)
+	}
+	for _, ns := range scopes.Namespaces {
+		ns := ns
 		gqlSourcesScope = append(gqlSourcesScope, &model.InstrumentationRuleSourcesScope{
-			WorkloadName:      &scope.WorkloadName,
-			WorkloadKind:      &kind,
-			WorkloadNamespace: &scope.WorkloadNamespace,
-			ContainerName:     &scope.ContainerName,
-			WorkloadLanguage:  &lang,
+			WorkloadNamespace: &ns,
+		})
+	}
+	for _, lang := range scopes.Languages {
+		l := model.SamplingWorkloadLanguage(lang)
+		gqlSourcesScope = append(gqlSourcesScope, &model.InstrumentationRuleSourcesScope{
+			WorkloadLanguage: &l,
 		})
 	}
 	return gqlSourcesScope

--- a/frontend/services/sampling/conversions.go
+++ b/frontend/services/sampling/conversions.go
@@ -3,6 +3,7 @@ package sampling
 import (
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
 	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/services"
@@ -87,36 +88,61 @@ func convertCostReductionRuleToModel(rule *v1alpha1.CostReductionRule) *model.Co
 
 // ---- Shared conversion helpers ----
 
-func sourcesScopeInputToCRD(scopes []*model.SourcesScopeInput) []k8sconsts.SourcesScope {
-	if scopes == nil {
+func sourcesScopeInputToCRD(in *model.SourcesScopesInput) *k8sconsts.SourcesScopes {
+	if in == nil {
 		return nil
 	}
-	result := make([]k8sconsts.SourcesScope, len(scopes))
-	for i, s := range scopes {
-		result[i] = k8sconsts.SourcesScope{
-			WorkloadName:      services.DerefString(s.WorkloadName),
-			WorkloadKind:      services.DerefK8sResourceKind(s.WorkloadKind),
-			WorkloadNamespace: services.DerefString(s.WorkloadNamespace),
-			WorkloadLanguage:  services.DerefSamplingWorkloadLanguage(s.WorkloadLanguage),
+	out := &k8sconsts.SourcesScopes{}
+	if len(in.Sources) > 0 {
+		out.Sources = make([]k8sconsts.PodWorkload, 0, len(in.Sources))
+		for _, s := range in.Sources {
+			if s == nil {
+				continue
+			}
+			out.Sources = append(out.Sources, k8sconsts.PodWorkload{
+				Name:      s.Name,
+				Namespace: s.Namespace,
+				Kind:      k8sconsts.WorkloadKind(s.Kind),
+			})
 		}
 	}
-	return result
+	if len(in.Namespaces) > 0 {
+		out.Namespaces = append([]string(nil), in.Namespaces...)
+	}
+	if len(in.Languages) > 0 {
+		out.Languages = make([]common.ProgrammingLanguage, 0, len(in.Languages))
+		for _, l := range in.Languages {
+			out.Languages = append(out.Languages, common.ProgrammingLanguage(l))
+		}
+	}
+	return out
 }
 
-func sourcesScopeCRDToModel(scopes []k8sconsts.SourcesScope) []*model.SourcesScope {
-	if len(scopes) == 0 {
+func sourcesScopeCRDToModel(in *k8sconsts.SourcesScopes) *model.SourcesScopes {
+	if in == nil {
 		return nil
 	}
-	result := make([]*model.SourcesScope, len(scopes))
-	for i, s := range scopes {
-		result[i] = &model.SourcesScope{
-			WorkloadName:      services.StringPtrIfNotEmpty(s.WorkloadName),
-			WorkloadKind:      services.K8sResourceKindPtrIfNotEmpty(s.WorkloadKind),
-			WorkloadNamespace: services.StringPtrIfNotEmpty(s.WorkloadNamespace),
-			WorkloadLanguage:  services.SamplingWorkloadLanguagePtrIfNotEmpty(s.WorkloadLanguage),
+	out := &model.SourcesScopes{}
+	if len(in.Sources) > 0 {
+		out.Sources = make([]*model.K8sWorkloadID, 0, len(in.Sources))
+		for _, s := range in.Sources {
+			out.Sources = append(out.Sources, &model.K8sWorkloadID{
+				Name:      s.Name,
+				Namespace: s.Namespace,
+				Kind:      model.K8sResourceKind(s.Kind),
+			})
 		}
 	}
-	return result
+	if len(in.Namespaces) > 0 {
+		out.Namespaces = append([]string(nil), in.Namespaces...)
+	}
+	if len(in.Languages) > 0 {
+		out.Languages = make([]model.SamplingWorkloadLanguage, 0, len(in.Languages))
+		for _, l := range in.Languages {
+			out.Languages = append(out.Languages, model.SamplingWorkloadLanguage(l))
+		}
+	}
+	return out
 }
 
 func headSamplingOperationMatcherInputToCRD(input *model.HeadSamplingOperationMatcherInput) *commonapisampling.HeadSamplingOperationMatcher {

--- a/frontend/webapp/graphql/mutations/sampling.ts
+++ b/frontend/webapp/graphql/mutations/sampling.ts
@@ -8,7 +8,7 @@ export const CREATE_NOISY_OPERATION_RULE = gql`
       ruleId
       name
       disabled
-      sourceScopes { workloadName workloadKind workloadNamespace workloadLanguage }
+      sourceScopes { sources { namespace kind name } namespaces languages }
       operation {
         httpServer { route routePrefix method }
         httpClient { serverAddress templatedPath templatedPathPrefix method }
@@ -25,7 +25,7 @@ export const UPDATE_NOISY_OPERATION_RULE = gql`
       ruleId
       name
       disabled
-      sourceScopes { workloadName workloadKind workloadNamespace workloadLanguage }
+      sourceScopes { sources { namespace kind name } namespaces languages }
       operation {
         httpServer { route routePrefix method }
         httpClient { serverAddress templatedPath templatedPathPrefix method }
@@ -50,7 +50,7 @@ export const CREATE_HIGHLY_RELEVANT_OPERATION_RULE = gql`
       ruleId
       name
       disabled
-      sourceScopes { workloadName workloadKind workloadNamespace workloadLanguage }
+      sourceScopes { sources { namespace kind name } namespaces languages }
       error
       durationAtLeastMs
       operation {
@@ -70,7 +70,7 @@ export const UPDATE_HIGHLY_RELEVANT_OPERATION_RULE = gql`
       ruleId
       name
       disabled
-      sourceScopes { workloadName workloadKind workloadNamespace workloadLanguage }
+      sourceScopes { sources { namespace kind name } namespaces languages }
       error
       durationAtLeastMs
       operation {
@@ -98,7 +98,7 @@ export const CREATE_COST_REDUCTION_RULE = gql`
       ruleId
       name
       disabled
-      sourceScopes { workloadName workloadKind workloadNamespace workloadLanguage }
+      sourceScopes { sources { namespace kind name } namespaces languages }
       operation {
         httpServer { route routePrefix method }
         kafkaConsumer { kafkaTopic }
@@ -116,7 +116,7 @@ export const UPDATE_COST_REDUCTION_RULE = gql`
       ruleId
       name
       disabled
-      sourceScopes { workloadName workloadKind workloadNamespace workloadLanguage }
+      sourceScopes { sources { namespace kind name } namespaces languages }
       operation {
         httpServer { route routePrefix method }
         kafkaConsumer { kafkaTopic }

--- a/frontend/webapp/graphql/queries/sampling.ts
+++ b/frontend/webapp/graphql/queries/sampling.ts
@@ -1,10 +1,9 @@
 import { gql } from '@apollo/client';
 
 const SOURCES_SCOPE_FIELDS = `
-  workloadName
-  workloadKind
-  workloadNamespace
-  workloadLanguage
+  sources { namespace kind name }
+  namespaces
+  languages
 `;
 
 const NOISY_OPERATION_FIELDS = `

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.234",
+    "@odigos/ui-kit": "0.0.235",
     "graphql": "^16.13.2",
     "next": "15.5.14",
     "react": "19.2.5",

--- a/frontend/webapp/types/sampling.ts
+++ b/frontend/webapp/types/sampling.ts
@@ -1,15 +1,21 @@
-export interface SourcesScope {
-  workloadName?: string | null;
-  workloadKind?: string | null;
-  workloadNamespace?: string | null;
-  workloadLanguage?: string | null;
+export interface K8sWorkloadId {
+  namespace: string;
+  kind: string;
+  name: string;
 }
 
-export interface SourcesScopeInput {
-  workloadName?: string | null;
-  workloadKind?: string | null;
-  workloadNamespace?: string | null;
-  workloadLanguage?: string | null;
+export type K8sSourceId = K8sWorkloadId;
+
+export interface SourcesScopes {
+  sources?: K8sWorkloadId[] | null;
+  namespaces?: string[] | null;
+  languages?: string[] | null;
+}
+
+export interface SourcesScopesInput {
+  sources?: K8sSourceId[] | null;
+  namespaces?: string[] | null;
+  languages?: string[] | null;
 }
 
 export interface HeadSamplingHttpServerMatcher {
@@ -50,7 +56,7 @@ export interface NoisyOperationRule {
   ruleId: string;
   name?: string | null;
   disabled: boolean;
-  sourceScopes?: SourcesScope[] | null;
+  sourceScopes?: SourcesScopes | null;
   operation?: HeadSamplingOperationMatcher | null;
   percentageAtMost?: number | null;
   notes?: string | null;
@@ -60,7 +66,7 @@ export interface HighlyRelevantOperationRule {
   ruleId: string;
   name?: string | null;
   disabled: boolean;
-  sourceScopes?: SourcesScope[] | null;
+  sourceScopes?: SourcesScopes | null;
   error: boolean;
   durationAtLeastMs?: number | null;
   operation?: TailSamplingOperationMatcher | null;
@@ -72,7 +78,7 @@ export interface CostReductionRule {
   ruleId: string;
   name?: string | null;
   disabled: boolean;
-  sourceScopes?: SourcesScope[] | null;
+  sourceScopes?: SourcesScopes | null;
   operation?: TailSamplingOperationMatcher | null;
   percentageAtMost: number;
   notes?: string | null;
@@ -93,7 +99,7 @@ export type SamplingRule = NoisyOperationRule | HighlyRelevantOperationRule | Co
 export interface NoisyOperationRuleInput {
   name?: string | null;
   disabled?: boolean | null;
-  sourceScopes?: SourcesScopeInput[] | null;
+  sourceScopes?: SourcesScopesInput | null;
   operation?: HeadSamplingOperationMatcher | null;
   percentageAtMost?: number | null;
   notes?: string | null;
@@ -102,7 +108,7 @@ export interface NoisyOperationRuleInput {
 export interface HighlyRelevantOperationRuleInput {
   name?: string | null;
   disabled?: boolean | null;
-  sourceScopes?: SourcesScopeInput[] | null;
+  sourceScopes?: SourcesScopesInput | null;
   error?: boolean | null;
   durationAtLeastMs?: number | null;
   operation?: TailSamplingOperationMatcher | null;
@@ -113,7 +119,7 @@ export interface HighlyRelevantOperationRuleInput {
 export interface CostReductionRuleInput {
   name?: string | null;
   disabled?: boolean | null;
-  sourceScopes?: SourcesScopeInput[] | null;
+  sourceScopes?: SourcesScopesInput | null;
   operation?: TailSamplingOperationMatcher | null;
   percentageAtMost: number;
   notes?: string | null;

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -635,10 +635,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.234":
-  version "0.0.234"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.234.tgz#e82d2e53fdc09bf461707c5723ae408d9c8b32bb"
-  integrity sha512-G1V4aDlNQk0tPZqFl0ExTUIjB1tE1ZdUhar84woivfQokBTWlE9+uXKsE/Vm+wPWoz/VOSstRwwo+km+Gbqx1g==
+"@odigos/ui-kit@0.0.235":
+  version "0.0.235"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.235.tgz#208b373daa48ee6ec7766f4a359e15d4fc9e8350"
+  integrity sha512-bn6CFKG54XV6SQI//ONG8mqrAji725FT0vdR6v8y1NvAGgeUAELILcXWwHASUrprqVWpImLq6XTWmFSVk8c2zQ==
   dependencies:
     "@xyflow/react" "^12.10.2"
     elkjs "^0.11.1"


### PR DESCRIPTION


Replace the per-rule list of single-match SourcesScope entries with a single SourcesScopes object containing sources, namespaces and languages lists. Lists are OR'd internally and AND'd across dimensions, which better matches the intended source-scoping semantics.